### PR TITLE
Add a Result.sequence function

### DIFF
--- a/SafetyFirst.Specs/ResultSpec.fs
+++ b/SafetyFirst.Specs/ResultSpec.fs
@@ -374,6 +374,8 @@ let ``Can tell if a Result is Ok or Error`` () =
       Ok 5 |> Result.isError = false
     @>
 
+let flip f a b = f b a
+
 [<Test>]
 let ``collects sequences of Results into a Result of a sequence of values`` () =
   test
@@ -381,6 +383,13 @@ let ``collects sequences of Results into a Result of a sequence of values`` () =
       Result.collect [Ok 1; Ok 2; Ok 3] |> Result.map Seq.toList = (Ok [1; 2; 3])
       &&
       Result.collect [Ok 1; Error "didn't"; Error "work"] |> Result.mapError Seq.toList = (Error ["didn't"; "work"])
+    @>
+
+  test 
+    <@ 
+      Result.traverse (flip Array.item' [|1..4|]) [1;2;3] = Ok [2;3;4]
+      &&
+      Result.traverse (flip Array.item' [|1..4|]) [1;5;2] |> Result.isError
     @>
 
   test 

--- a/SafetyFirst.Specs/ResultSpec.fs
+++ b/SafetyFirst.Specs/ResultSpec.fs
@@ -383,6 +383,31 @@ let ``collects sequences of Results into a Result of a sequence of values`` () =
       Result.collect [Ok 1; Error "didn't"; Error "work"] |> Result.mapError Seq.toList = (Error ["didn't"; "work"])
     @>
 
+  test 
+    <@
+      Result.sequence [Ok 1; Ok 2; Ok 3] = (Ok [1; 2; 3])
+      &&
+      Result.sequence [Ok 1; Error "didn't"; Error "work"] = Error "didn't"
+      &&
+      Result.sequence [] = Ok []
+    @>
+
+  let mutable x = 0
+  let ans = 
+    Result.sequence (seq { 
+      for i in 1 .. 3 do 
+        x <- x + 1
+        yield Ok x 
+      
+      yield Error "failed in the middle"
+
+      for i in 4 .. 6 do
+        x <- x + 1
+        yield Ok x
+    })
+    
+  test <@ ans = Error "failed in the middle" && x = 3 @>
+
 type PretendError = PretendError
 
 [<Test>]

--- a/SafetyFirst/ResultModule.fs
+++ b/SafetyFirst/ResultModule.fs
@@ -108,16 +108,29 @@ module Result =
 
     in collect' (Ok []) (Seq.toList results)
 
-  let private concatResults results =
-    let rec concat state rs =
-      match rs with
-      | head::tail -> 
-        match head with 
-        | Ok x -> concat (x::state) tail
-        | Error err -> Error err
-      | [] -> Ok (state |> Seq.ofList |> Seq.rev)
-
-    concat [] (results |> Seq.toList)
+  /// <summary>
+  /// Collects a sequence of Results into a single Result of the sequence of values.
+  /// If all of the Results are Ok, returns an Ok of the sequence of contained values.  
+  /// If any of the Results are Error, returns the first Error encountered, and does not
+  /// evaluate any of the rest of the sequence.
+  /// <c>collect [Ok 1; Ok 2; Ok 3]</c> would return <c>Ok [1; 2; 3]</c>, but 
+  /// <c>collect [Ok 1; Error "err"; Error "fail"]</c> would return <c>Error "err"</c>
+  /// </summary>
+  [<CompiledName("$notForC#_sequence")>]
+  let sequence (results : Result<_,_> seq) =
+    let enum = results.GetEnumerator ()
+    let mutable err = None
+    let okVals = 
+      [
+        while err = None && enum.MoveNext () do
+          match enum.Current with
+          | Error e -> err <- Some e
+          | Ok o -> yield o
+      ]
+    
+    match err with 
+    | Some e -> Error e
+    | None -> Ok okVals
 
   /// <summary>
   /// If all the Results are ok, "unwraps" the ok values and passes them
@@ -126,7 +139,7 @@ module Result =
   /// </summary>
   [<CompiledName("$notForC#_bindAll")>]
   let bindAll onOk results = 
-    concatResults results
+    sequence results
     |> Result.bind onOk
 
   /// <summary>
@@ -178,7 +191,7 @@ module Result =
   /// </summary>
   [<CompiledName("$notForC#_mapAll")>]
   let mapAll onOk results = 
-    concatResults results
+    sequence results
     |> Result.map onOk
 
   /// <summary>


### PR DESCRIPTION
 which is like Result.collect, but fails at the first error instead of collecting all errors.
Fixes #74 