### PR TITLE
add functor and semigroup instances for most common NonEmpty collections

### DIFF
--- a/SafetyFirst.Specs/NonEmptySpec.fs
+++ b/SafetyFirst.Specs/NonEmptySpec.fs
@@ -1,0 +1,18 @@
+module SafetyFirst.Specs.NonEmptySpec
+
+open NUnit.Framework
+open Swensen.Unquote
+
+open FSharpPlus
+open SafetyFirst
+
+[<Test>]
+let ``can map and append non empty colletions via FSharpPlus`` () = 
+  let (NonEmpty xs) = ((+) "hello ") <<| NonEmpty.assume ["world"; "SafetyFirst"]  
+  test <@ xs = ["hello world"; "hello SafetyFirst"] @>
+
+
+  let (NonEmpty ys) = (NonEmpty.assume [|1.0 .. 5.0|] |>> ((+) 2.0)) ++ (NonEmpty.assume [|7.0 .. 9.0|] |>> ((+) 1.0))
+  test <@ ys = [| 3.0 .. 10.0|] @>
+
+

--- a/SafetyFirst.Specs/NonEmptySpec.fs
+++ b/SafetyFirst.Specs/NonEmptySpec.fs
@@ -7,12 +7,11 @@ open FSharpPlus
 open SafetyFirst
 
 [<Test>]
-let ``can map and append non empty colletions via FSharpPlus`` () = 
+let ``can map and append non empty collections via FSharpPlus`` () = 
   let (NonEmpty xs) = ((+) "hello ") <<| NonEmpty.assume ["world"; "SafetyFirst"]  
   test <@ xs = ["hello world"; "hello SafetyFirst"] @>
 
 
   let (NonEmpty ys) = (NonEmpty.assume [|1.0 .. 5.0|] |>> ((+) 2.0)) ++ (NonEmpty.assume [|7.0 .. 9.0|] |>> ((+) 1.0))
   test <@ ys = [| 3.0 .. 10.0|] @>
-
 

--- a/SafetyFirst.Specs/SafetyFirst.Specs.fsproj
+++ b/SafetyFirst.Specs/SafetyFirst.Specs.fsproj
@@ -18,6 +18,7 @@
     <Compile Include="Lazy.fs" />
     <Compile Include="ConversionsSpec.fs" />
     <Compile Include="MatchSpec.fs" />
+    <Compile Include="NonEmptySpec.fs" />
     <Compile Include="SeqSpec.fs" />
     <Compile Include="ListSpec.fs" />
     <Compile Include="ArraySpec.fs" />
@@ -31,6 +32,7 @@
   <ItemGroup>
     <PackageReference Include="FsCheck" Version="2.11.0" />
     <PackageReference Include="fsharp.core" Version="4.6.2" />
+    <PackageReference Include="FSharpPlus" Version="1.1.7" />
     <PackageReference Include="microsoft.net.test.sdk" Version="15.7.2" />
     <PackageReference Include="nunit" Version="3.10.1" />
     <PackageReference Include="nunit3TestAdapter" Version="3.10.0" />


### PR DESCRIPTION
Fixes #75.
The approach here doesn't add a dependency to F#+, so that's nice, but we're literally just adding Map overloads for each common NonEmpty sequence type.  We have list, array, set, map, IDictionary, Dictionary, seq, and ResizeArray.  I couldn't figure out how to define a generic one for _any_ sequence type, even if I did add a dependency to F#+.
This only  adds Functor and Semigroup instances.  It'd be nice to have applicative and monad instances, but since we're adding separate overloads for each sequence type all to the one NonEmpty class, I can't define different `Return` implementations, since all the overloads have the same input type.  
I'd like to perhaps add traversable instances at some point, but that would definitely require a dependency on F#+, so I'll hold off until v5.0