### PR TITLE
Extend the 'result' CE with applicative appending errors instead of taking the first failure

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.com/ntwilson/SafetyFirst.svg?branch=master)](https://travis-ci.com/ntwilson/SafetyFirst)
+![tests](https://github.com/ntwilson/SafetyFirst/actions/workflows/tests.yml/badge.svg)
 
 ## SafetyFirst
 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ SalesRep VIP(IEnumerable<SalesRep> salesReps) =>
     .Unless("No sales reps have been loaded into the system.  You must provide at least one sales rep");
 ```
 
-This has a higher development cost than using the partial `maxBy` function or `First` method, but if the exception is thrown, it provides a better error message because we now know a lot more about the context of the problem than we would from inside the maxBy function.  We know that specifically our seq of SalesReps is empty, and can reflect that in the error message.  Also this provides a lot more information to the reader of the `vip` function because it's obvious what the assumptions this function makes are (in this case, that the input includes at least one sales rep).
+This has a higher development cost than using the partial `maxBy` function or `First` method, but if the exception is thrown, it provides a better error message because we now know a lot more about the context of the problem than we would from inside the `maxBy` function.  We know that specifically our seq of SalesReps is empty, and can reflect that in the error message.  Also this provides a lot more information to the reader of the `vip` function because it's obvious what the assumptions this function makes are (in this case, that the input includes at least one sales rep).
 
 Since the Result type already contains error information in it, the Result type also has an `expect` function that functions just like `unless` but doesn't require an additional message.  So you could do:
 
@@ -136,6 +136,25 @@ result {
 ```
 
 (note that for `Result<_,_>` expressions, the Error type must be the same for all results used in the expression).
+
+If you're using F#5 or greater, you can take advantage of ["Applicative Computation Expressions"](https://docs.microsoft.com/en-us/dotnet/fsharp/whats-new/fsharp-50#applicative-computation-expressions) which adds `and!` bindings inside a `result` expression. When using `and!` bindings, any errors will be aggregated together (using [F#+'s semigroup append](http://fsprojects.github.io/FSharpPlus/abstraction-semigroup.html)). For example, 
+
+```F#
+result {
+  let! x = Error ["no x value available"]
+  and! y = Error ["no y value available"]
+  return x + y
+} // returns Error ["no x value available"; "no y value available"]
+
+result {
+  let! x = Error ["no x value available"]
+
+  let! y = Error ["no y value available"]
+  and! z = Error ["no z value available"]
+
+  return x + y + z
+} // returns Error ["no x value available"]
+```
 
 ##### C# types
 

--- a/SafetyFirst.Specs/ResultSpec.fs
+++ b/SafetyFirst.Specs/ResultSpec.fs
@@ -249,6 +249,58 @@ let ``can use computation expressions to bind and map Results`` () =
       resultC = (Ok 15)
     @>
 
+[<Test>]
+let ``can use the applicative CE to combine errors together`` () = 
+  let tryToGetA = Ok 5
+  let tryToGetB = Ok 10
+  let add x y = x + y
+  let add' x y = Ok (x + y)
+
+  let resultA : Result<_, string> = 
+    result {
+      let! x = tryToGetA
+      and! y = tryToGetB
+      return add x y 
+    }
+
+  test <@ resultA = (Ok 15) @>
+
+  let resultB = 
+    result { 
+      let! x = Error [ "x failed" ]
+      and! y = tryToGetA
+      and! z = Error [ "z failed" ]
+      let a = 20
+      return a+x+y+z
+    }
+
+  test <@ resultB = Error ["x failed"; "z failed"] @>
+
+  let resultC = 
+    result {
+      let! x = Error "x failed"
+
+      let! y = tryToGetA
+      and! z = Error "z failed"
+
+      return x+y+z
+    }
+
+  test <@ resultC = Error "x failed" @>
+
+  let resultC = 
+    result {
+      let! x = tryToGetA
+
+      let! y = Error ["y failed"]
+      and! z = Error ["z failed"]
+
+      return x+y+z
+    }
+
+  test <@ resultC = Error ["y failed"; "z failed"] @>
+
+
 
 [<Test>]
 let ``can use a default value for a failed result`` () =

--- a/SafetyFirst.Specs/ResultSpec.fs
+++ b/SafetyFirst.Specs/ResultSpec.fs
@@ -301,6 +301,27 @@ let ``can use the applicative CE to combine errors together`` () =
   test <@ resultC = Error ["y failed"; "z failed"] @>
 
 
+type CustomError = CustomError of string
+
+[<Test>]
+let ``can still create non applicative result expressions on non semigroup errors but will error for applicatives`` () = 
+  let resultA = 
+    result { 
+      let! x = Ok 5
+      let! y = Error <| CustomError "Failed!"
+      return x + y
+    }
+
+  test <@ resultA = Error (CustomError "Failed!") @>
+
+  // let ``uncomment to observe failure to compile`` = 
+  //   result { 
+  //     let! x = Ok 5
+  //     and! y = Error <| CustomError "Failed!"
+  //     return x + y
+  //   }
+
+
 
 [<Test>]
 let ``can use a default value for a failed result`` () =

--- a/SafetyFirst/ResultModule.fs
+++ b/SafetyFirst/ResultModule.fs
@@ -2,6 +2,9 @@ namespace SafetyFirst
 
 open System.Runtime.CompilerServices
 
+open FSharpPlus
+open SafetyFirst
+
 /// <summary>
 /// Used for computation expressions.  Use <c>Result.expr</c> or <c>ResultExpression.result</c> 
 /// to create the expression. 
@@ -10,6 +13,13 @@ type ResultExpression () =
   member this.Bind (x, onOk) = Result.bind onOk x
   member this.Return x = Ok x
   member this.ReturnFrom x = x
+  member inline this.MergeSources(t1, t2) = 
+    match t1, t2 with
+    | Ok r1, Ok r2 -> Ok (r1, r2)
+    | Error e1, Error e2 -> Error (e1 ++ e2)
+    | Error e, _ | _, Error e -> Error e
+
+  member this.BindReturn(x, f) = Result.map f x
 
 [<AutoOpen>]
 module ResultExpression =


### PR DESCRIPTION
This is a follow up to #82 that implements the idea in there of extending the existing `result` computation expression instead of adding a new one for applicative validation where we append the errors together. 